### PR TITLE
Facebook content placeholder

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,6 @@
 ## Miscellaneous
 
 *   Tip: Apart Profiel / gebruiker in Chrome zonder plugins
-*   [Use gzip compression on assets](http://softstribe.com/wordpress/enable-gzip-compression-in-wordpress/)
 
 ## HTTP optimisation
 
@@ -57,3 +56,7 @@
 ### Fonts
 
 ### Images
+*   Downsize images with Adobe PhotoShop, by saving for web
+
+### Perceived Performance
+*   [Facebook content placeholder](http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html)


### PR DESCRIPTION
Facebook content placeholder is a way of perceiving performance by showing how the ui will look like when the content is loaded. A user can for instance already see where the profile image will be before the section is loaded.