### PR TITLE
Void Space min-height

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -3,6 +3,7 @@
 ## Miscellaneous
 
 *   Tip: Apart Profiel / gebruiker in Chrome zonder plugins
+*   [Use gzip compression on assets](http://softstribe.com/wordpress/enable-gzip-compression-in-wordpress/)
 
 ## HTTP optimisation
 
@@ -58,11 +59,6 @@
 ### Images
 
 *   Downsize images with Adobe PhotoShop, by saving for web
-*   Downsize images with Adobe PhotoShop, by saving for web
 
-### Perceived Performance
-*   [Facebook content placeholder](http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html)
-
-## Server-side optimisation
-
-- Upgrade PHP to version 7. [It's much faster.](http://blog.wpoven.com/2016/03/31/php-5-6-vs-php-7-wordpress-sites-nginx/)
+### Void Space
+*   Set min-height for <div class="container-wrap"/> in order to stop the footer from beingat the top of the page onload.


### PR DESCRIPTION
Right now the footer is on top of the page because the content that will be in <div class="container-wrap"/> is not loaded yet. In order to fix this and stop the jumping around the div should have a min-height.