### PR TITLE
Enable nginx content caching

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -58,9 +58,9 @@
 ### Images
 
 *   Downsize images with Adobe PhotoShop, by saving for web
-*   Downsize images with Adobe PhotoShop, by saving for web
 
 ### Perceived Performance
+
 *   [Facebook content placeholder](http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html)
 
 ## Server-side optimisation

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,6 @@
 ## Miscellaneous
 
 *   Tip: Apart Profiel / gebruiker in Chrome zonder plugins
-*   [Use gzip compression on assets](http://softstribe.com/wordpress/enable-gzip-compression-in-wordpress/)
 
 ## HTTP optimisation
 
@@ -59,15 +58,12 @@
 ### Images
 
 *   Downsize images with Adobe PhotoShop, by saving for web
+*   Downsize images with Adobe PhotoShop, by saving for web
 
 ### Perceived Performance
-
 *   [Facebook content placeholder](http://cloudcannon.com/deconstructions/2014/11/15/facebook-content-placeholder-deconstruction.html)
 
 ## Server-side optimisation
- 
-*  Upgrade PHP to version 7. [It's much faster.](http://blog.wpoven.com/2016/03/31/php-5-6-vs-php-7-wordpress-sites-nginx/)
 
-### Void Space
-
-*   Set min-height for <div class="container-wrap"/> in order to stop the footer from beingat the top of the page onload.
+- Upgrade PHP to version 7. [It's much faster.](http://blog.wpoven.com/2016/03/31/php-5-6-vs-php-7-wordpress-sites-nginx/)
+- Enable the nginx content cache. [Documentation](https://www.nginx.com/resources/admin-guide/content-caching/)


### PR DESCRIPTION
As 100% of the site is static content, caching requests on the server could speed up responses times by completely bypassing PHP (Wordpress) and serving a generated cached page from memory.