### PR TITLE
progressive jpeg's

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -31,6 +31,7 @@
 *   [client hints](http://httpwg.org/http-extensions/client-hints.html)
 *   [`srcset`](https://css-tricks.com/responsive-images-youre-just-changing-resolutions-use-srcset/) and [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Example_4_Using_the_srcset_and_sizes_attributes)
 *   [`<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
+*   [Progressive JPEG's](https://www.thewebmaster.com/dev/2016/feb/10/how-progressive-jpegs-can-speed-up-your-website/)
 
 ## Caching
 


### PR DESCRIPTION
With baseline JPEG's, there is whitespace until the image has fully loaded. With progressive JPEG's, the image will appear blurry while loading.