### PR TITLE
lazyload images

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -32,6 +32,7 @@
 *   [client hints](http://httpwg.org/http-extensions/client-hints.html)
 *   [`srcset`](https://css-tricks.com/responsive-images-youre-just-changing-resolutions-use-srcset/) and [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Example_4_Using_the_srcset_and_sizes_attributes)
 *   [`<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
+*   [Lazyload images](http://verlok.github.io/lazyload/)
 
 ## Caching
 


### PR DESCRIPTION
Use lazyload to let the browser load images when they appear in the viewport, instead of loading all the images on the page on load. This way you reduce images being loaded, which may never be shown to the user, because he/she doesn't get to the end of the page.