### PR TITLE
Minify plugin for WordPress replaced

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -46,7 +46,7 @@
 
 ## Minify
 
-*   For WordPress, use Minify plugin [Better Wordpress Minify](https://nl.wordpress.org/plugins/bwp-minify/)
+*   Minify plugin for WordPress [Autoptimize](https://wordpress.org/plugins/autoptimize/): HTML, CSS and JS. Also have option for above the fold and critical CSS.
 
 ### CSS
 


### PR DESCRIPTION
Replace Better WordPress Minify with Autoptimize plugin, more advanced options and up to date.