### PR TITLE
Use sprites

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -37,6 +37,7 @@
 *   [`<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
 *   Compress images with [TinyPNG](https://tinypng.com/) or [TinyJPG](https://tinyjpg.com/) to reduce filesizes before upload
 *   [Lazyload images](http://verlok.github.io/lazyload/)
+*   Use sprites (Les requests) for small images
 
 ## Caching
 
@@ -46,7 +47,7 @@
 
 ## Minify
 
-*   Minify plugin for WordPress [Autoptimize](https://wordpress.org/plugins/autoptimize/): HTML, CSS and JS. Also have option for above the fold and critical CSS.
+*   For WordPress, use Minify plugin [Better Wordpress Minify](https://nl.wordpress.org/plugins/bwp-minify/)
 
 ### CSS
 


### PR DESCRIPTION
Rather than include each image as a separate image file, it is much more memory and bandwidth-friendly to send them as a single image, so the number of HTTP requests is reduced.