### PR TITLE
Minimize cookie size

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,7 @@
 *   Fallbacks for HTML, CSS and JavaScript
 *   Reduce inline javascript
 *   Eliminate render-blocking JavaScript and CSS in above-the-fold content
+*   Minimize cookie size
 
 ## HTTP optimisation
 


### PR DESCRIPTION
If a cookie is too large, the page will load slower or even produce an error like: 400 bad requests, and the page refuses to load.

Source:
http://www.thewindowsclub.com/400-bad-request