### PR TITLE
Replace font-awesome with SVG-icons

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -86,6 +86,7 @@
 *   load fallback font before custom font show content faster
     https://github.com/bramstein/fontfaceobserver
 *   Enhance font after async loading to prevent FOIT
+*   Replace font-awesome with SVG-icons
 
 ### Images
 


### PR DESCRIPTION
Replace font-awesome with SVG-icons. When your icon font fails, the browser treats it like any other font and replaces it with a fallback. Best-case scenario, you’ve chosen your fallback characters carefully and something weird-looking but communicative still loads. Worse-case scenario (and far more often), the user sees something completely incongruous, usually the dreaded “missing character” glyph. This is also the case during the  critical render.

Source: https://cloudfour.com/thinks/seriously-dont-use-icon-fonts/